### PR TITLE
fix: Ensure all activation methods work correctly

### DIFF
--- a/anhilate/background.js
+++ b/anhilate/background.js
@@ -1,17 +1,16 @@
 /**
- * Toggles the activation state of the extension for a given tab.
- * When activated, the content script is injected into the page.
- * When deactivated, a message is sent to the content script to deactivate.
+ * A single, reusable function to toggle the activation state of the extension.
+ * This function is called by all activation methods (toolbar, shortcut, context menu).
  * @param {object} tab - The tab to toggle the activation state for.
  */
-function toggleActivation(tab) {
+function unifiedToggleActivation(tab) {
   if (!tab || !tab.id) {
     return;
   }
   browser.storage.local.get('activeTabs').then(result => {
     let activeTabs = result.activeTabs || {};
     if (activeTabs[tab.id]) {
-      // Deactivate by sending a message
+      // Deactivate by sending a message to the content script
       browser.tabs.sendMessage(tab.id, { action: "deactivate" });
     } else {
       // Activate
@@ -23,10 +22,34 @@ function toggleActivation(tab) {
   });
 }
 
-// Listen for a click on the browser action
-browser.browserAction.onClicked.addListener(toggleActivation);
+// 1. Toolbar button activation
+browser.browserAction.onClicked.addListener(unifiedToggleActivation);
 
-// Listen for messages from the content script
+// 2. Keyboard shortcut activation
+browser.commands.onCommand.addListener((command) => {
+  if (command === "toggle-anhilate") {
+    browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+      if (tabs[0]) {
+        unifiedToggleActivation(tabs[0]);
+      }
+    });
+  }
+});
+
+// 3. Context menu activation
+browser.contextMenus.create({
+  id: "anhilate-context-menu",
+  title: "Anhilate",
+  contexts: ["all"]
+});
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "anhilate-context-menu") {
+    unifiedToggleActivation(tab);
+  }
+});
+
+// Listen for messages from the content script to confirm deactivation
 browser.runtime.onMessage.addListener((message, sender) => {
   if (message.action === "deactivated") {
     browser.storage.local.get('activeTabs').then(result => {

--- a/anhilate/manifest.json
+++ b/anhilate/manifest.json
@@ -12,20 +12,25 @@
   },
   "permissions": [
     "activeTab",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "browser_action": {
-    "default_icon": "icons/32.png",
+    "default_icon": {
+      "16": "icons/16.png",
+      "32": "icons/32.png"
+    },
     "default_title": "Anhilate"
   },
   "background": {
     "scripts": ["background.js"]
   },
   "commands": {
-    "_execute_browser_action": {
+    "toggle-anhilate": {
       "suggested_key": {
         "default": "Ctrl+Shift+X"
-      }
+      },
+      "description": "Toggle the Anhilate element selector"
     }
   },
   "web_accessible_resources": [


### PR DESCRIPTION
This commit fixes several critical issues that prevented the "anhilate" WebExtension from functioning as intended.

The primary changes include:

1.  **Unified Activation Logic:** A single, unified function in the background script now handles the activation and deactivation of the extension.

2.  **Keyboard Shortcut:** The keyboard shortcut (Ctrl+Shift+X) is now correctly defined as a named command in the manifest and is properly handled by a `commands.onCommand` listener in the background script.

3.  **Toolbar Icon:** The `browser_action` in the manifest has been corrected to ensure the toolbar icon appears reliably in Firefox.

4.  **Context Menu:** A context menu item labeled "Anhilate" has been added. It is created in the background script and triggers the same activation logic as the other methods. The required `contextMenus` permission has also been added to the manifest.

5.  **Manifest Cleanup:** The manifest has been reviewed and corrected to ensure it is fully compliant with Manifest V2 for Firefox.

With these fixes, all three activation methods (toolbar button, keyboard shortcut, and context menu) now reliably toggle the element selection mode on and off.